### PR TITLE
Add "support us" section

### DIFF
--- a/sponsorship/README.md
+++ b/sponsorship/README.md
@@ -48,7 +48,7 @@ Because we are a non-profit organisation, we will typically put any surplus fund
 
 If your business is about products or services that could improve the overall meetup experience, and benefit our community, please consider supporting this group by providing us community licenses or access to free merchandise! Great examples of companies that have already agreed on this kind of "sponsorship" are:
 
-* Jetbrains: three free licenses every month for our attendees to give away in a raffle fashion
+* Jetbrains: three free licenses every month for our attendees to give away in a raffle
 * 1Password: they granted us a community account that we can use to share admin/passwords/details within us organisers
 * Stickermule: they kindly provide stickers for our events
 

--- a/sponsorship/README.md
+++ b/sponsorship/README.md
@@ -50,7 +50,7 @@ If your business is about products or services that could improve the overall me
 
 * Jetbrains: three free licenses every month for our attendees to give away in a raffle
 * 1Password: a free community license for the organisers to be able to share passwords and sensitive data securely
-* Stickermule: they kindly provide stickers for our events
+* Stickermule: stickers with the London Gophers logo to be distributed at our events
 
 We're incredibly grateful to everyone who would like to contribute, one way or another, and we'll make sure our friends will know about your kindness!
 

--- a/sponsorship/README.md
+++ b/sponsorship/README.md
@@ -46,7 +46,7 @@ Because we are a non-profit organisation, we will typically put any surplus fund
 
 ## 👨‍👩‍👦‍👦 Support us
 
-If your business is about products or services that could improve the overall meetup experience, and benefit our community, please consider supporting this group by providing us community licenses or access to free merchandise! Great examples of companies that have already agreed on this kind of "sponsorship" are:
+If your business is about products or services that could improve the overall meetup experience, and benefit our community, please consider supporting this group by providing us community licenses or access to free merchandise! Great examples of companies which have supported us this way are:
 
 * Jetbrains: three free licenses every month for our attendees to give away in a raffle
 * 1Password: a free community license for the organisers to be able to share passwords and sensitive data securely

--- a/sponsorship/README.md
+++ b/sponsorship/README.md
@@ -44,6 +44,18 @@ In addition, recurring sponsors will be listed prominently on our website.
 
 Because we are a non-profit organisation, we will typically put any surplus funds towards conference scholarship funds such as https://www.gophercon.co.uk/scholarships/.
 
+## 👨‍👩‍👦‍👦 Support us
+
+If your business is about products or services that could improve the overall meetup experience, and benefit our community, please consider supporting this group by providing us community licenses or access to free merchandise! Great examples of companies that have already agreed on this kind of "sponsorship" are:
+
+* Jetbrains: three free licenses every month for our attendees to give away in a raffle fashion
+* 1Password: they granted us a community account that we can use to share admin/passwords/details within us organisers
+* Stickermule: they kindly provide stickers for our events
+
+We're incredibly grateful to everyone who would like to contribute, one way or another, and we'll make sure our friends will know about your kindness!
+
+---
+
 As mentioned above, the organising committee of London Gophers are volunteers. We are always on the lookout for people keen to join our team!
 
 ### Contact Us

--- a/sponsorship/README.md
+++ b/sponsorship/README.md
@@ -49,7 +49,7 @@ Because we are a non-profit organisation, we will typically put any surplus fund
 If your business is about products or services that could improve the overall meetup experience, and benefit our community, please consider supporting this group by providing us community licenses or access to free merchandise! Great examples of companies that have already agreed on this kind of "sponsorship" are:
 
 * Jetbrains: three free licenses every month for our attendees to give away in a raffle
-* 1Password: they granted us a community account that we can use to share admin/passwords/details within us organisers
+* 1Password: a free community license for the organisers to be able to share passwords and sensitive data securely
 * Stickermule: they kindly provide stickers for our events
 
 We're incredibly grateful to everyone who would like to contribute, one way or another, and we'll make sure our friends will know about your kindness!


### PR DESCRIPTION
I'd like to introduce the concept of "supporters" alongside "sponsors". Supporters instead of helping us financially, will give us licenses or products they directly make (i.e. Jetbrains, 1Password, Stickermule...)